### PR TITLE
Leave out Sprite Image Source Files from Build

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -139,7 +139,8 @@ activate :authors do |authors|
 end
 
 ignore '/author.html'
-
+ignore '/images/retina/*.png'
+ignore '/images/sprites/*.png'
 
 ###
 # Bower Components Support


### PR DESCRIPTION
## 何のPR？

`middleman build`を行う際に、Sprite ImageのSourceファイルまでCopyされるのを防ぐPRです。
（数秒でも`build`を短縮したい…！）
## 確認方法
- [x] `middleman build`時に下記のファイル達が`build`ディレクトリにコピー**されていないこと。**
  - `source/images/sprites/*.png`
  - `source/images/retina/*.png`
- [x] `middleman build`時に下記のファイルが**生成されること。**
  - `build/images/sprites-xxxxxxxx.png`
  - `build/images/retina-xxxxxxxx.png`
