### PR TITLE
Fix XML Title and Author

### DIFF
--- a/source/feed.xml.builder
+++ b/source/feed.xml.builder
@@ -1,23 +1,23 @@
 xml.instruct!
-xml.feed "xmlns" => "http://www.w3.org/2005/Atom" do
-  xml.title data.site.title
+xml.feed 'xmlns' => 'http://www.w3.org/2005/Atom' do
+  xml.title data.site.name
   xml.subtitle data.site.description
   xml.id data.site.url
-  xml.link "href" => data.site.url
-  xml.link "href" => data.site.url, "rel" => "self"
+  xml.link 'href' => data.site.url
+  xml.link 'href' => data.site.url, 'rel' => 'self'
   xml.updated(blog.articles.first.date.to_time.iso8601) unless blog.articles.empty?
-  xml.author { xml.name "Blog Author" }
+  xml.author { xml.name data.site.author }
 
   blog.articles[0..15].each do |article|
     xml.entry do
       xml.title article.title
-      xml.link "rel" => "alternate", "href" => URI.join(data.site.url, article.url)
+      xml.link 'rel' => 'alternate', 'href' => URI.join(data.site.url, article.url)
       xml.id URI.join(data.site.url, article.url)
       xml.published article.date.to_time.iso8601
       xml.updated File.mtime(article.source_file).iso8601
-      xml.author { xml.name "Article Author" }
-      # xml.summary article.summary, "type" => "html"
-      xml.content article.body, "type" => "html"
+      xml.author { xml.name article.data.authors }
+      # xml.summary article.summary, 'type' => 'html'
+      xml.content article.body, 'type' => 'html'
     end
   end
 end


### PR DESCRIPTION
#### なんのPR
Feed XMLのBug修正/調整を反映するためのPRです。

#### やったこと
- [x] XMLのTitleが表示されていない件を修正した
- [x] サイト/記事のAuthor情報を設定した

#### 確認方法
1. [http://tech.feedforce.jp/feed](http://tech.feedforce.jp/feed)を開く
1. [https://feedforce-tech-blog-pr-36.herokuapp.com/feed.xml](https://feedforce-tech-blog-pr-36.herokuapp.com/feed.xml)を開く
1. 以下の修正がされていることを確認する。

| 変更箇所 | 変更前 | 変更後                                                    |
|--------------|-----------|-----------------------------------------------------|
| 3行目あたり | <title/>  | <title>feedforce Engineers' blog</title> |
| 10行目あたり | <name>Blog Author</name> | <name>feedforce Inc.</name> |
| 各記事の<author><name>のところ | <name>Article Author</name> | <name>{{執筆者名}}</name> |