### PR TITLE
Fix `code` Style

### DIFF
--- a/source/css/fftt.sass
+++ b/source/css/fftt.sass
@@ -456,18 +456,11 @@ footer
     list-style: circle
   pre
     margin-bottom: 30px
-  p
-    code
-      background: #222222
-      border-radius: 4px
-      color: #fff
-      padding: .2em .4em
-    .caption-text
-      font-size: 0.8rem
-      color: #999
-      margin-top: 4px
-      text-align: center
-      display: block
+  code
+    background: #222222
+    border-radius: 4px
+    color: #fff
+    padding: .2em .4em
   code
     font-family: $codefont
   blockquote
@@ -1345,4 +1338,3 @@ li.L9
   /*
 
 @import "syntax"
-


### PR DESCRIPTION
#### これはなんぞ
[経緯](https://feedforce.slack.com/archives/tech-blog/p1424950791000010)

過去記事への影響は、良い意味であるかな？
移行時に、`WordPress`の記事内容(`HTML`)を`Markdown`にしているので、ほぼ全部に対して修正かかります。

#### 確認方法
- [x] リスト内の`code`にスタイルが適用されていること
  - 背景付いてたら無問題です。