### PR TITLE
Allow publish_future_dated

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -34,6 +34,7 @@ activate :blog do |blog|
   blog.page_link = 'page/{num}'
 
   blog.new_article_template = 'templates/article.tt'
+  blog.publish_future_dated = true
 end
 
 page '/feed.xml', layout: false


### PR DESCRIPTION
> https://middlemanapp.com/jp/basics/blogging/#下書き
>
> 下書きは development モードの場合のみ出力します。
>
> 未来の日付の記事も未公開になります。 定期的にサイトをビルドするように cron ジョブを使うことで, 指定した時刻に自動的に記事が公開されます。 この挙動は publish_future_dated を true に設定することで無効化できます。

middleman-blogは未来の記事は公開しませんが、うちの場合は都合がわるいので許可してみました。

今回の変数は `$ middleman build` に影響しますが、`$ middleman server` には影響しません。
serverはdevelopmentモードみたいですね。ローカルで気づかなかったのはそういうわけです。

### 確認方法

* 修正前
    * 未来の日付の記事を作り `$ middleman build` すると記事が作られない。あっても消される
* 修正後
    * 未来の日付の記事を作り `$ middleman build` すると記事が作られる
