### PR TITLE
Remove eyecatch links

### DIFF
--- a/source/posts/2014-10-17-jenkins-server-ci.md
+++ b/source/posts/2014-10-17-jenkins-server-ci.md
@@ -4,7 +4,7 @@ date: 2014-10-17 15:42 JST
 authors: masutaka
 tags: infrastructure, test
 ---
- [![logo-title](/images/2014/10/logo-title.png)](http://jenkins-ci.org/)
+![jenkins logo](/images/2014/10/logo-title.png)
 
 お久しぶりです。アジャイル推進おじさん改め、サーバCIおじさんの増田です。
 

--- a/source/posts/2015-04-08-elasticache.html.md
+++ b/source/posts/2015-04-08-elasticache.html.md
@@ -4,7 +4,7 @@ date: 2015-04-08 14:00 JST
 authors: masutaka
 tags: aws, operation
 ---
- [![fluentd logo](/images/2015/04/fluentd-logo.png)](http://www.fluentd.org/)
+![fluentd logo](/images/2015/04/fluentd-logo.png)
 
 ご無沙汰しております。増田でございます。
 
@@ -52,7 +52,7 @@ AOF（Append-Only File）を有効にして（appendonly=yes）トランザク�
 
 ソーシャルPLUSでは当初からZabbixを使っており、KyotoTycoonの時は監視用のスクリプトを用意してZabbixに登録していました。
 
-ElastiCacheではCloudWatchが使えるので、fluentd経由でZabbixに送信することでシンプルかつ既存の監視と馴染ませることが出来ました。
+ElastiCacheではCloudWatchが使えるので、[fluentd](http://www.fluentd.org/)経由でZabbixに送信することでシンプルかつ既存の監視と馴染ませることが出来ました。
 
 ![watch elasticache](/images/2015/04/watch-elasticache.png)
 

--- a/source/posts/2015-05-19-rails-fluent-bugsnag.html.md
+++ b/source/posts/2015-05-19-rails-fluent-bugsnag.html.md
@@ -5,7 +5,7 @@ authors: ff_koshigoe
 tags: resume, operation
 ---
 
-[![bugsnag logo](/images/2015/05/logo-bugsnag.png)](https://bugsnag.com/)
+![bugsnag logo](/images/2015/05/logo-bugsnag.png)
 
 こんにちは。2月に入社して以来、とうとう勉強会の担当が回ってきた腰越です。
 

--- a/source/posts/2015-05-20-heroku-recent-topics.html.md
+++ b/source/posts/2015-05-20-heroku-recent-topics.html.md
@@ -5,11 +5,11 @@ authors: ff_koshigoe
 tags: operation
 ---
 
-[![Heroku logo](/images/2015/05/heroku-logotype-horizontal-purple.png)](https://heroku.com/)
+![Heroku logo](/images/2015/05/heroku-logotype-horizontal-purple.png)
 
 こんにちは。腰越と申します。
 
-最近、数年ぶりに仕事で Heroku を使う様になったので、久しぶりに使って感じたこと、Heroku で最近できる様になってうれしかった事などを書いてみたいと思います。
+最近、数年ぶりに仕事で [Heroku](https://heroku.com/) を使う様になったので、久しぶりに使って感じたこと、Heroku で最近できる様になってうれしかった事などを書いてみたいと思います。
 
 <!--more-->
 


### PR DESCRIPTION
> https://feedforce.slack.com/archives/tech-blog/p1432302244000064
> そいや制作mtgで出た話だけど、fluentd とか herokuロゴの画像にリンクいらないかも。
> 記事詳細を見ようしたら外部サイトに飛ぶ的な誤クリックを誘発するような気がする

たしかにそうかもと思ったので修正してみました。

@koshigoe 
いかがでしょう？