### PR TITLE
Google prettyprint でコードが改行されずに突き抜けてしまう件

### DIFF
--- a/source/css/fftt.sass
+++ b/source/css/fftt.sass
@@ -490,6 +490,9 @@ footer
     word-wrap: break-word
   pre > code
     display: block
+  /* fix prettyprint non break words */
+  pre .prettyprint
+    overflow: auto
   blockquote
     quotes: "“" "”"
     margin: 30px 0


### PR DESCRIPTION
現時点で最新の Firefox, Chrome で発生する。

![ruby elixir_phoenix_part1___feedforce_engineers__blog](https://cloud.githubusercontent.com/assets/294443/14096029/93fb4ada-f5a0-11e5-8eb2-1b2fa4d84a94.png)

私のCSS力ではうまく改行させられなかったので、せめて突き抜けないように `overflow: auto;` してブロック内でスクロールが効くようにしました。

つらい。