### PR TITLE
HerokuのReview App用に設定を変更した

### DIFF
--- a/.buildpacks
+++ b/.buildpacks
@@ -1,3 +1,0 @@
-https://github.com/heroku/heroku-buildpack-nodejs
-https://github.com/heroku/heroku-buildpack-ruby
-https://github.com/hashicorp/heroku-buildpack-middleman

--- a/app.json
+++ b/app.json
@@ -1,21 +1,19 @@
 {
   "name": "tech.feedforce.jp",
-  "scripts": {
-  },
   "env": {
-    "BUILDPACK_URL": {
-      "required": true
-    },
     "NODE_MODULES_CACHE": {
       "required": true
     }
   },
-  "addons": [
-
-  ],
   "buildpacks": [
     {
-      "url": "https://github.com/ddollar/heroku-buildpack-multi.git"
+      "url": "heroku/node"
+    },
+    {
+      "url": "heroku/ruby"
+    },
+    {
+      "url": "https://github.com/hashicorp/heroku-buildpack-middleman.git"
     }
   ]
 }

--- a/app.json
+++ b/app.json
@@ -7,7 +7,7 @@
   },
   "buildpacks": [
     {
-      "url": "heroku/node"
+      "url": "heroku/nodejs"
     },
     {
       "url": "heroku/ruby"


### PR DESCRIPTION
## 経緯

```sh
-----> Multipack app detected
WARNING: This buildpack is no longer maintained.
Please choose a different buildpack or go to https://github.com/ddollar/heroku-buildpack-multi
and fork it to your own account.
This buildpack will cease to function at the stroke of midnight on January 1, 2017.
 !     Push rejected, failed to compile Multipack app.
 !     Push failed
```

とのことなので、対応を実施した。

## 参考情報とか

- https://devcenter.heroku.com/articles/buildpacks
- https://devcenter.heroku.com/articles/app-json-schema