### PR TITLE
情報が古くなっていたのでプロフィールを更新

### DIFF
--- a/data/author.yml
+++ b/data/author.yml
@@ -230,7 +230,7 @@
 - id: tsub
   name: tsub
   thumbnail: tsub.png
-  profile: "2016年卒内定者エンジニア。<br>
+  profile: "2016年新卒入社のエンジニア。<br>
             マンガが大好き。Kindleで絶賛散財中<br>
             日付が変わった瞬間Webマンガを漁り始めます"
   media:

--- a/data/author.yml
+++ b/data/author.yml
@@ -218,7 +218,7 @@
 - id: otofu_square
   name: otofu_square
   thumbnail: otofu_square.png
-  profile: "2016年卒内定者エンジニア。<br>
+  profile: "2016年新卒入社のエンジニア。<br>
             音楽大好き、ギター大好き。<br>
             Steamでゲームを買っては積み重ねる日々を送っています…。"
   media:


### PR DESCRIPTION
## 経緯
プロフィール欄に`2016年卒内定者エンジニア`とあるが、もう内定者ではないので情報が古くなってました。

## やったこと
プロフィール情報が古かったので更新しました。
ついでに @otofu-square も同様に更新しました。