### PR TITLE
Exclude registration people from ranking

### DIFF
--- a/script/contribution-ranking.rb
+++ b/script/contribution-ranking.rb
@@ -50,7 +50,7 @@ class Ranking
 
   # Getting target authors
   def target_authors
-    @target_authors ||= yaml.map { |y| y['id'] }
+    @target_authors ||= yaml.map { |y| y['id'] unless y['resignation'] }
   end
 
   # Getting yaml data


### PR DESCRIPTION
Slack に通知するランキングから、殿堂入りの方々を除外しました。
PR #231 のおかげで、変更しやすかった。
